### PR TITLE
engraph: Build a table with the total number of orders per customer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+
+profiles.yml
+.user.yml

--- a/models/orders_per_customer.sql
+++ b/models/orders_per_customer.sql
@@ -1,0 +1,13 @@
+with orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+grouped_orders as (
+    select
+        customer_id,
+        count(order_id) as total_orders
+    from orders
+    group by customer_id
+)
+
+select * from grouped_orders


### PR DESCRIPTION
I have created a new model named 'model.jaffle_shop.orders_per_customer' that groups by CUSTOMER_ID and counts the number of orders per customer using the stg_orders model. The count column is named 'total_orders'.