### PR TITLE
engraph: Build a table with the total number of orders per customer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/orders_per_customer.sql
+++ b/models/orders_per_customer.sql
@@ -1,0 +1,25 @@
+with orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customers as (
+    select * from {{ ref('stg_customers') }}
+),
+
+joined as (
+    select
+        c.customer_id,
+        c.first_name,
+        c.last_name,
+        o.order_id
+    from customers c
+    join orders o on c.customer_id = o.customer_id
+)
+
+select
+    customer_id,
+    first_name,
+    last_name,
+    count(order_id) as total_orders
+from joined
+group by customer_id, first_name, last_name


### PR DESCRIPTION
I have created a new model named 'orders_per_customer' that joins 'stg_orders' and 'stg_customers' on CUSTOMER_ID and groups by CUSTOMER_ID to get the total number of orders per customer. The resulting table has columns CUSTOMER_ID, FIRST_NAME, LAST_NAME, and TOTAL_ORDERS.