### PR TITLE
engraph: Build a table with the total number of orders per customer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/orders_per_customer.sql
+++ b/models/orders_per_customer.sql
@@ -1,0 +1,36 @@
+{{
+  config(
+    materialized='table'
+  )
+}}
+
+with orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customers as (
+    select * from {{ ref('stg_customers') }}
+),
+
+joined_data as (
+    select
+        c.customer_id,
+        c.first_name,
+        c.last_name,
+        o.order_id
+    from customers c
+    join orders o
+    on c.customer_id = o.customer_id
+),
+
+grouped_data as (
+    select
+        customer_id,
+        first_name,
+        last_name,
+        count(order_id) as total_orders
+    from joined_data
+    group by customer_id, first_name, last_name
+)
+
+select * from grouped_data

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -80,3 +80,105 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+
+    columns:
+      - name: customer_id
+        description: This is a unique identifier for a customer
+        tests:
+          - unique
+          - not_null
+
+      - name: first_name
+        description: Customer's first name. PII.
+
+      - name: last_name
+        description: Customer's last name. PII.
+
+      - name: first_order
+        description: Date (UTC) of a customer's first order
+
+      - name: most_recent_order
+        description: Date (UTC) of a customer's most recent order
+
+      - name: number_of_orders
+        description: Count of the number of orders a customer has placed
+
+      - name: total_order_amount
+        description: Total value (AUD) of a customer's orders
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+
+      - name: amount
+        description: Total amount (AUD) of the order
+        tests:
+          - not_null
+
+      - name: credit_card_amount
+        description: Amount of the order (AUD) paid for by credit card
+        tests:
+          - not_null
+
+      - name: coupon_amount
+        description: Amount of the order (AUD) paid for by coupon
+        tests:
+          - not_null
+
+      - name: bank_transfer_amount
+        description: Amount of the order (AUD) paid for by bank transfer
+        tests:
+          - not_null
+
+      - name: gift_card_amount
+        description: Amount of the order (AUD) paid for by gift card
+        tests:
+          - not_null
+
+version: 2
+
+models:
+  - name: orders_per_customer
+    description: This table shows the total number of orders per customer.
+    columns:
+      - name: customer_id
+        description: The unique identifier for the customer.
+        tests:
+          - unique
+          - not_null
+      - name: first_name
+        description: The first name of the customer.
+      - name: last_name
+        description: The last name of the customer.
+      - name: total_orders
+        description: The total number of orders placed by the customer.
+        tests:
+          - not_null


### PR DESCRIPTION
I have created a new dbt model named 'orders_per_customer' that joins the stg_orders and stg_customers models on the CUSTOMER_ID column and counts the number of orders per customer. The final table has columns CUSTOMER_ID, FIRST_NAME, LAST_NAME, and TOTAL_ORDERS.