### PR TITLE
engraph: create a table with the top 3 customers and how much they spent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/top_customers.sql
+++ b/models/top_customers.sql
@@ -1,0 +1,36 @@
+with orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customers as (
+    select * from {{ ref('stg_customers') }}
+),
+
+payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+joined_data as (
+    select
+        c.customer_id,
+        c.first_name,
+        c.last_name,
+        p.amount
+    from customers c
+    join orders o on c.customer_id = o.customer_id
+    join payments p on o.order_id = p.order_id
+),
+
+grouped_data as (
+    select
+        customer_id,
+        first_name,
+        last_name,
+        sum(amount) as total_spent
+    from joined_data
+    group by customer_id, first_name, last_name
+)
+
+select * from grouped_data
+order by total_spent desc
+limit 3


### PR DESCRIPTION
I have created a new model named 'top_customers' that joins stg_orders, stg_customers, and stg_payments on their respective keys (CUSTOMER_ID and ORDER_ID). The model groups by CUSTOMER_ID, FIRST_NAME, and LAST_NAME, and calculates the sum of AMOUNT as total_spent. The result is ordered by total_spent descending and limited to the top 3 customers. The model is saved in the model.jaffle_shop.top_customers and the schema has been written.