### PR TITLE
engraph: create a table with the 3 customers that spent the most, their ids and their spent amount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -80,3 +80,101 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+
+    columns:
+      - name: customer_id
+        description: This is a unique identifier for a customer
+        tests:
+          - unique
+          - not_null
+
+      - name: first_name
+        description: Customer's first name. PII.
+
+      - name: last_name
+        description: Customer's last name. PII.
+
+      - name: first_order
+        description: Date (UTC) of a customer's first order
+
+      - name: most_recent_order
+        description: Date (UTC) of a customer's most recent order
+
+      - name: number_of_orders
+        description: Count of the number of orders a customer has placed
+
+      - name: total_order_amount
+        description: Total value (AUD) of a customer's orders
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+
+      - name: amount
+        description: Total amount (AUD) of the order
+        tests:
+          - not_null
+
+      - name: credit_card_amount
+        description: Amount of the order (AUD) paid for by credit card
+        tests:
+          - not_null
+
+      - name: coupon_amount
+        description: Amount of the order (AUD) paid for by coupon
+        tests:
+          - not_null
+
+      - name: bank_transfer_amount
+        description: Amount of the order (AUD) paid for by bank transfer
+        tests:
+          - not_null
+
+      - name: gift_card_amount
+        description: Amount of the order (AUD) paid for by gift card
+        tests:
+          - not_null
+
+version: 2
+
+models:
+  - name: top_customers_spent
+    description: This model calculates the total amount spent by each customer and selects the top 3 customers based on their spent amount.
+    columns:
+      - name: customer_id
+        description: The unique identifier of the customer.
+        tests:
+          - unique
+          - not_null
+      - name: total_spent
+        description: The total amount spent by the customer.
+        tests:
+          - not_null

--- a/models/top_customers_spent.sql
+++ b/models/top_customers_spent.sql
@@ -1,0 +1,29 @@
+with customer_orders as (
+    select
+        c.customer_id,
+        o.order_id
+    from {{ ref('stg_customers') }} as c
+    join {{ ref('stg_orders') }} as o
+    on c.customer_id = o.customer_id
+),
+
+customer_payments as (
+    select
+        co.customer_id,
+        sum(p.amount) as total_spent
+    from customer_orders as co
+    join {{ ref('stg_payments') }} as p
+    on co.order_id = p.order_id
+    group by co.customer_id
+),
+
+top_customers as (
+    select
+        customer_id,
+        total_spent
+    from customer_payments
+    order by total_spent desc
+    limit 3
+)
+
+select * from top_customers


### PR DESCRIPTION
I have created a new dbt model named 'top_customers_spent' that calculates the total amount spent by each customer using the stg_customers, stg_orders, and stg_payments models. The model joins the stg_customers and stg_orders models on customer_id, and joins the stg_orders and stg_payments models on order_id. Then, it groups by customer_id and sums the amount column to calculate the total amount spent by each customer. Finally, it selects the top 3 customers based on their spent amount. The output includes the customer_id and spent amount.