### PR TITLE
engraph: create a sales table 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,7 @@
+{% set source_table = ref('orders') %}
+SELECT
+    ORDER_ID,
+    CUSTOMER_ID,
+    ORDER_DATE,
+    AMOUNT AS SALES_AMOUNT
+FROM {{ source_table }}

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -80,3 +80,108 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+
+    columns:
+      - name: customer_id
+        description: This is a unique identifier for a customer
+        tests:
+          - unique
+          - not_null
+
+      - name: first_name
+        description: Customer's first name. PII.
+
+      - name: last_name
+        description: Customer's last name. PII.
+
+      - name: first_order
+        description: Date (UTC) of a customer's first order
+
+      - name: most_recent_order
+        description: Date (UTC) of a customer's most recent order
+
+      - name: number_of_orders
+        description: Count of the number of orders a customer has placed
+
+      - name: total_order_amount
+        description: Total value (AUD) of a customer's orders
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+
+      - name: amount
+        description: Total amount (AUD) of the order
+        tests:
+          - not_null
+
+      - name: credit_card_amount
+        description: Amount of the order (AUD) paid for by credit card
+        tests:
+          - not_null
+
+      - name: coupon_amount
+        description: Amount of the order (AUD) paid for by coupon
+        tests:
+          - not_null
+
+      - name: bank_transfer_amount
+        description: Amount of the order (AUD) paid for by bank transfer
+        tests:
+          - not_null
+
+      - name: gift_card_amount
+        description: Amount of the order (AUD) paid for by gift card
+        tests:
+          - not_null
+
+version: 2
+models:
+  - name: sales
+    description: Sales model created using the orders table as a source
+    columns:
+      - name: ORDER_ID
+        description: Unique identifier for each order
+        tests:
+          - unique
+          - not_null
+      - name: CUSTOMER_ID
+        description: Unique identifier for each customer
+        tests:
+          - not_null
+      - name: ORDER_DATE
+        description: Date when the order was placed
+        tests:
+          - not_null
+      - name: SALES_AMOUNT
+        description: Amount of the sale
+        tests:
+          - not_null


### PR DESCRIPTION
{
    "is_possible": true,
    "explanation": "I have created a sales table using the model.jaffle_shop.orders table as a source. The new model is named 'model.jaffle_shop.sales' and contains the columns ORDER_ID, CUSTOMER_ID, ORDER_DATE, and SALES_AMOUNT.",
}