### PR TITLE
engraph: create a sales table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,23 @@
+with orders as (
+    select * from {{ ref('orders') }}
+),
+
+customers as (
+    select * from {{ ref('stg_customers') }}
+),
+
+sales as (
+    select
+        orders.order_id,
+        orders.customer_id,
+        customers.first_name,
+        customers.last_name,
+        orders.order_date,
+        orders.status,
+        orders.amount
+    from orders
+    join customers
+        on orders.customer_id = customers.customer_id
+)
+
+select * from sales

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -80,3 +80,104 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+
+    columns:
+      - name: customer_id
+        description: This is a unique identifier for a customer
+        tests:
+          - unique
+          - not_null
+
+      - name: first_name
+        description: Customer's first name. PII.
+
+      - name: last_name
+        description: Customer's last name. PII.
+
+      - name: first_order
+        description: Date (UTC) of a customer's first order
+
+      - name: most_recent_order
+        description: Date (UTC) of a customer's most recent order
+
+      - name: number_of_orders
+        description: Count of the number of orders a customer has placed
+
+      - name: total_order_amount
+        description: Total value (AUD) of a customer's orders
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+
+      - name: amount
+        description: Total amount (AUD) of the order
+        tests:
+          - not_null
+
+      - name: credit_card_amount
+        description: Amount of the order (AUD) paid for by credit card
+        tests:
+          - not_null
+
+      - name: coupon_amount
+        description: Amount of the order (AUD) paid for by coupon
+        tests:
+          - not_null
+
+      - name: bank_transfer_amount
+        description: Amount of the order (AUD) paid for by bank transfer
+        tests:
+          - not_null
+
+      - name: gift_card_amount
+        description: Amount of the order (AUD) paid for by gift card
+        tests:
+          - not_null
+
+models:
+  - name: sales
+    description: This model joins the orders and stg_customers models on the customer_id column and includes the order_id, customer_id, first_name, last_name, order_date, status, and amount columns.
+    columns:
+      - name: order_id
+        description: The unique identifier for each order.
+      - name: customer_id
+        description: The unique identifier for each customer.
+      - name: first_name
+        description: The first name of the customer.
+      - name: last_name
+        description: The last name of the customer.
+      - name: order_date
+        description: The date the order was placed.
+      - name: status
+        description: The status of the order (e.g., completed, returned).
+      - name: amount
+        description: The total amount of the order.


### PR DESCRIPTION
I have created a new model called sales that joins the orders and stg_customers models on the customer_id column and includes the order_id, customer_id, first_name, last_name, order_date, status, and amount columns. The model is saved as model.jaffle_shop.sales, and the schema has been written to the schema file.