### PR TITLE
engraph: create a sales table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,33 @@
+{{
+  config(
+    materialized='view'
+  )
+}}
+
+with orders as (
+    select
+        order_id,
+        customer_id,
+        order_date,
+        status
+    from {{ ref('stg_orders') }}
+),
+
+payments as (
+    select
+        order_id,
+        payment_method,
+        amount
+    from {{ ref('stg_payments') }}
+)
+
+select
+    o.order_id,
+    o.customer_id,
+    o.order_date,
+    o.status,
+    p.payment_method,
+    p.amount
+from orders o
+join payments p
+on o.order_id = p.order_id


### PR DESCRIPTION
I have created a sales table by joining the stg_orders and stg_payments models on the ORDER_ID column and selecting relevant columns such as ORDER_ID, CUSTOMER_ID, ORDER_DATE, STATUS, PAYMENT_METHOD, and AMOUNT. The new model is named 'sales' and has been saved to model.jaffle_shop.sales.