### PR TITLE
engraph: create a sales table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,10 @@
+with sales as (
+    select
+        o.*,
+        c.*
+    from {{ ref('orders') }} as o
+    join {{ ref('stg_customers') }} as c
+        on o.customer_id = c.customer_id
+)
+
+select * from sales

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -80,3 +80,112 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+
+    columns:
+      - name: customer_id
+        description: This is a unique identifier for a customer
+        tests:
+          - unique
+          - not_null
+
+      - name: first_name
+        description: Customer's first name. PII.
+
+      - name: last_name
+        description: Customer's last name. PII.
+
+      - name: first_order
+        description: Date (UTC) of a customer's first order
+
+      - name: most_recent_order
+        description: Date (UTC) of a customer's most recent order
+
+      - name: number_of_orders
+        description: Count of the number of orders a customer has placed
+
+      - name: total_order_amount
+        description: Total value (AUD) of a customer's orders
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+
+      - name: amount
+        description: Total amount (AUD) of the order
+        tests:
+          - not_null
+
+      - name: credit_card_amount
+        description: Amount of the order (AUD) paid for by credit card
+        tests:
+          - not_null
+
+      - name: coupon_amount
+        description: Amount of the order (AUD) paid for by coupon
+        tests:
+          - not_null
+
+      - name: bank_transfer_amount
+        description: Amount of the order (AUD) paid for by bank transfer
+        tests:
+          - not_null
+
+      - name: gift_card_amount
+        description: Amount of the order (AUD) paid for by gift card
+        tests:
+          - not_null
+
+models:
+  - name: sales
+    description: This model joins the orders and stg_customers models on the customer_id column, selecting all columns from both models.
+    columns:
+      - name: order_id
+        description: The unique identifier for each order.
+      - name: customer_id
+        description: The unique identifier for each customer.
+      - name: order_date
+        description: The date the order was placed.
+      - name: status
+        description: The current status of the order (e.g., completed, returned).
+      - name: credit_card_amount
+        description: The amount paid by credit card for the order.
+      - name: coupon_amount
+        description: The amount paid by coupon for the order.
+      - name: bank_transfer_amount
+        description: The amount paid by bank transfer for the order.
+      - name: gift_card_amount
+        description: The amount paid by gift card for the order.
+      - name: amount
+        description: The total amount paid for the order.
+      - name: first_name
+        description: The first name of the customer.
+      - name: last_name
+        description: The last name of the customer.


### PR DESCRIPTION
I have created a sales table by joining the orders model with the stg_customers model on the customer_id column. The new model is called sales and is saved as model.jaffle_shop.sales.