### PR TITLE
engraph: Give a sales table with our top 3 best customers and their lifetime value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/top_customers.sql
+++ b/models/top_customers.sql
@@ -1,0 +1,31 @@
+with customer_orders as (
+    select
+        c.customer_id,
+        c.first_name,
+        c.last_name,
+        o.order_id
+    from {{ ref('stg_customers') }} as c
+    join {{ ref('stg_orders') }} as o
+    on c.customer_id = o.customer_id
+),
+
+customer_payments as (
+    select
+        co.customer_id,
+        co.first_name,
+        co.last_name,
+        sum(p.amount) as lifetime_value
+    from customer_orders as co
+    join {{ ref('stg_payments') }} as p
+    on co.order_id = p.order_id
+    group by co.customer_id, co.first_name, co.last_name
+)
+
+select
+    customer_id,
+    first_name,
+    last_name,
+    lifetime_value
+from customer_payments
+order by lifetime_value desc
+limit 3


### PR DESCRIPTION
I have created a new dbt model named 'model.jaffle_shop.top_customers' that joins the stg_customers, stg_orders, and stg_payments models on customer_id and order_id, groups by customer_id, first_name, and last_name, sums the amount column as lifetime_value, orders by lifetime_value in descending order, and limits the result to the top 3 customers. This model provides the sales table with the top 3 best customers and their lifetime value as requested.