### PR TITLE
engraph: Create a table with the most popular payment methods used by jaffle shop customers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/popular_payment_methods.sql
+++ b/models/popular_payment_methods.sql
@@ -1,0 +1,13 @@
+
+WITH payment_counts AS (
+    SELECT
+        PAYMENT_METHOD,
+        COUNT(*) as payment_count
+    FROM {{ ref('raw_payments') }}
+    GROUP BY PAYMENT_METHOD
+)
+SELECT
+    PAYMENT_METHOD,
+    payment_count
+FROM payment_counts
+ORDER BY payment_count DESC


### PR DESCRIPTION
I have created a new dbt model named 'popular_payment_methods' that selects PAYMENT_METHOD and COUNT(*) as payment_count from seed.jaffle_shop.raw_payments, groups by PAYMENT_METHOD, and orders by payment_count DESC. The model is saved in the model.jaffle_shop.popular_payment_methods file, and the schema is written using the schema_writer tool.