### PR TITLE
engraph: Create a table with the purchases made by credit card only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/credit_card_purchases.sql
+++ b/models/credit_card_purchases.sql
@@ -1,0 +1,7 @@
+{{
+    config(materialized='table')
+}}
+
+select *
+from {{ ref('stg_payments') }}
+where payment_method = 'credit_card'


### PR DESCRIPTION
I have created a new dbt model named 'model.jaffle_shop.credit_card_purchases' that filters the purchases made by credit card only. This model selects all columns from the stg_payments model where the PAYMENT_METHOD is 'credit_card'.