### PR TITLE
engraph: can you create a table with the sales completed using credit card only?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/credit_card_payments.sql
+++ b/models/credit_card_payments.sql
@@ -1,0 +1,11 @@
+{{
+    config(materialized='view')
+}}
+
+with credit_card_payments as (
+    select *
+    from {{ ref('stg_payments') }}
+    where payment_method = 'Credit Card'
+)
+
+select * from credit_card_payments


### PR DESCRIPTION
I have created a new model named 'credit_card_payments' that filters the stg_payments model for credit card payments only. The model can be found at model.jaffle_shop.credit_card_payments.