### PR TITLE
engraph: what were the total sales in march 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/total_sales_march_2018.sql
+++ b/models/total_sales_march_2018.sql
@@ -1,0 +1,8 @@
+
+WITH filtered_orders AS (
+    SELECT *
+    FROM {{ ref('orders') }}
+    WHERE order_date >= '2018-03-01' AND order_date <= '2018-03-31'
+)
+SELECT SUM(amount) AS total_sales
+FROM filtered_orders


### PR DESCRIPTION
I explored the existing models and found that the model.jaffle_shop.orders contained the necessary information to calculate the total sales. I created a new model named 'model.jaffle_shop.total_sales_march_2018' that filters the data for the date range between 2018-03-01 and 2018-03-31 and calculates the total sales by summing the 'AMOUNT' column. The total sales for March 2018 are 622.