### PR TITLE
engraph: total sales last year? 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/total_sales_last_year.sql
+++ b/models/total_sales_last_year.sql
@@ -1,0 +1,13 @@
+{% set last_year_start = '2021-01-01' %}
+{% set last_year_end = '2021-12-31' %}
+
+with orders as (
+    select * from {{ ref('orders') }}
+    where order_date between '{{ last_year_start }}' and '{{ last_year_end }}'
+),
+
+total_sales as (
+    select sum(amount) as total_sales_last_year from orders
+)
+
+select * from total_sales


### PR DESCRIPTION
To answer this request, I first explored the existing dbt models and found that the 'model.jaffle_shop.orders' model contains the sales information. I then created a new dbt model named 'model.jaffle_shop.total_sales_last_year' that calculates the sum of the 'AMOUNT' column from the 'orders' model where the 'ORDER_DATE' is between the first day of last year and the last day of last year. The resulting column is named 'total_sales_last_year'.