### PR TITLE
engraph: total sales across all orders last year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/total_sales_last_year.sql
+++ b/models/total_sales_last_year.sql
@@ -1,0 +1,9 @@
+
+with last_year_orders as (
+    select *
+    from {{ ref('orders') }}
+    where order_date >= date_trunc('year', current_date - interval '1 year')
+      and order_date < date_trunc('year', current_date)
+)
+select sum(amount) as total_sales_last_year
+from last_year_orders


### PR DESCRIPTION
I created a new model named `total_sales_last_year` that calculates the total sales across all orders last year. The sum of the amount column from orders where the order_date is between the first day of last year and the last day of last year is saved in the `total_sales_last_year` column. You can use this model to get the required information.