### PR TITLE
engraph: what were the total sales in march 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/total_sales_march_2021.sql
+++ b/models/total_sales_march_2021.sql
@@ -1,0 +1,9 @@
+
+WITH orders_march AS (
+    SELECT *
+    FROM {{ ref('orders') }}
+    WHERE order_date >= '2021-03-01' AND order_date <= '2021-03-31'
+)
+
+SELECT SUM(amount) as total_sales_march
+FROM orders_march


### PR DESCRIPTION
I have created a new model named 'model.jaffle_shop.total_sales_march_2021' that calculates the total sales for March 2021 using the data from the 'model.jaffle_shop.orders' model. The new model filters the data for the given date range and sums the 'AMOUNT' column to get the total sales.