### PR TITLE
engraph: total sales last year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/total_sales_last_year.sql
+++ b/models/total_sales_last_year.sql
@@ -1,11 +1,16 @@
-{% set last_year_start = '2021-01-01' %}
-{% set last_year_end = '2021-12-31' %}
+{{
+    config(
+        materialized='table'
+    )
+}}
 
 with last_year_sales as (
     select
         sum(amount) as total_sales_last_year
     from {{ ref('orders') }}
-    where order_date between '{{ last_year_start }}' and '{{ last_year_end }}'
+    where
+        order_date >= date_trunc('year', current_date - interval '1 year')
+        and order_date < date_trunc('year', current_date)
 )
 
 select * from last_year_sales

--- a/models/total_sales_last_year.sql
+++ b/models/total_sales_last_year.sql
@@ -1,0 +1,11 @@
+{% set last_year_start = '2021-01-01' %}
+{% set last_year_end = '2021-12-31' %}
+
+with last_year_sales as (
+    select
+        sum(amount) as total_sales_last_year
+    from {{ ref('orders') }}
+    where order_date between '{{ last_year_start }}' and '{{ last_year_end }}'
+)
+
+select * from last_year_sales


### PR DESCRIPTION
I attempted to create a new model named 'total_sales_last_year' to calculate the total sales for last year, but the model is not being added to the list of available models. As a result, I am unable to retrieve the total sales value to answer the request.