### PR TITLE
engraph: which payment methods led to most revenue in 2018?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/payment_revenue_2018.sql
+++ b/models/payment_revenue_2018.sql
@@ -1,0 +1,34 @@
+{{
+  config(materialized='view')
+}}
+
+with orders_filtered as (
+  select *
+  from {{ ref('orders') }}
+  where date_part('year', order_date) = 2018
+),
+
+joined_data as (
+  select
+    o.order_id,
+    o.order_date,
+    o.customer_id,
+    o.status,
+    cc.payment_method,
+    cc.amount
+  from orders_filtered as o
+  join {{ ref('credit_card_payments') }} as cc
+    on o.order_id = cc.order_id
+),
+
+grouped_data as (
+  select
+    payment_method,
+    sum(amount) as revenue
+  from joined_data
+  group by payment_method
+)
+
+select *
+from grouped_data
+order by revenue desc


### PR DESCRIPTION
I have created a new model named 'model.jaffle_shop.payment_revenue_2018' that calculates the revenue for each payment method in 2018. This model joins the 'model.jaffle_shop.orders' with the 'model.jaffle_shop.credit_card_payments' on the order_id column, filters the data for the year 2018 using the order_date column, groups the data by payment_method, and calculates the sum of the amount column as revenue. The data is then ordered by revenue in descending order.