### PR TITLE
engraph: which payment methods generate the most revenue?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/payment_method_revenue.sql
+++ b/models/payment_method_revenue.sql
@@ -1,0 +1,19 @@
+{{
+  config(
+    materialized='view'
+  )
+}}
+
+with payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+revenue_by_payment_method as (
+    select
+        payment_method,
+        sum(amount) as total_revenue
+    from payments
+    group by payment_method
+)
+
+select * from revenue_by_payment_method order by total_revenue desc


### PR DESCRIPTION
I created a new model named 'payment_method_revenue' using the 'model.jaffle_shop.stg_payments' model. The model aggregates revenue by payment methods and orders the result by total revenue in descending order. The payment method with the highest total revenue is the one that generates the most revenue.