### PR TITLE
engraph: who were the highest paying customers in 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/highest_paying_customers_2018.sql
+++ b/models/highest_paying_customers_2018.sql
@@ -1,0 +1,39 @@
+with customers as (
+    select * from {{ ref('stg_customers') }}
+),
+
+payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+orders as (
+    select * from {{ ref('orders') }}
+    where date_part('year', order_date) = 2018
+),
+
+combined_data as (
+    select
+        customers.customer_id,
+        customers.first_name,
+        customers.last_name,
+        orders.order_id,
+        payments.amount
+    from customers
+    join orders
+        on customers.customer_id = orders.customer_id
+    join payments
+        on orders.order_id = payments.order_id
+),
+
+grouped_data as (
+    select
+        customer_id,
+        first_name,
+        last_name,
+        sum(amount) as total_amount_paid
+    from combined_data
+    group by customer_id, first_name, last_name
+)
+
+select * from grouped_data
+order by total_amount_paid desc


### PR DESCRIPTION
I created a new model named highest_paying_customers_2018 that combines stg_customers, stg_payments, and orders models, filters the data for 2018, groups the data by customer_id, first_name, and last_name, calculates the total amount paid by each customer, and orders the results by the total amount paid in descending order. The top 5 highest paying customers in 2018 are Howard R. with $99, Kathleen P. with $65, Norma C. with $64, Rose M. with $57, and Christina W. with $57.