### PR TITLE
engraph: create a table showing the highest paying customers in 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/highest_paying_customers_2018.sql
+++ b/models/highest_paying_customers_2018.sql
@@ -1,0 +1,18 @@
+
+WITH orders_2018 AS (
+    SELECT *
+    FROM {{ ref('stg_orders') }}
+    WHERE EXTRACT(YEAR FROM order_date) = 2018
+),
+
+joined_data AS (
+    SELECT o.customer_id, p.amount
+    FROM orders_2018 o
+    JOIN {{ ref('stg_payments') }} p ON o.order_id = p.order_id
+)
+
+SELECT customer_id, SUM(amount) as total_payment
+FROM joined_data
+GROUP BY customer_id
+ORDER BY total_payment DESC
+


### PR DESCRIPTION
I created a new dbt model named `highest_paying_customers_2018` that joins `stg_payments` and `stg_orders` on `order_id`, filters the `order_date` to only include 2018, groups by `customer_id`, and sums the `amount` column to get the total payment per customer. The results are ordered by the total payment in descending order. The top 5 highest paying customers are customer IDs 51, 3, 46, 54, and 30.