### PR TITLE
engraph: create a table showing the highest paying customers in 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/highest_paying_customers_2018.sql
+++ b/models/highest_paying_customers_2018.sql
@@ -1,0 +1,16 @@
+
+WITH orders_2018 AS (
+    SELECT *
+    FROM {{ ref('orders') }}
+    WHERE EXTRACT(YEAR FROM order_date) = 2018
+),
+joined_data AS (
+    SELECT o.customer_id, c.first_name, c.last_name, o.amount
+    FROM orders_2018 o
+    JOIN {{ ref('customers') }} c ON o.customer_id = c.customer_id
+)
+SELECT customer_id, first_name, last_name, SUM(amount) as total_amount
+FROM joined_data
+GROUP BY customer_id, first_name, last_name
+ORDER BY total_amount DESC
+


### PR DESCRIPTION
I created a new model 'model.jaffle_shop.highest_paying_customers_2018' that joins 'model.jaffle_shop.orders' and 'model.jaffle_shop.customers' on CUSTOMER_ID, filters the orders by ORDER_DATE within the year 2018, and then groups by CUSTOMER_ID, sums the AMOUNT, and orders by the total amount paid in descending order. The top 5 highest paying customers are listed in the answer.