### PR TITLE
engraph: who were the highest paying customers in 2018?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ logs/
 **/.DS_Store
 profiles.yml
 .user.yml
+profiles.yml
+.user.yml

--- a/models/highest_paying_customers_2018.sql
+++ b/models/highest_paying_customers_2018.sql
@@ -1,0 +1,33 @@
+{% set year = 2018 %}
+
+with orders_filtered as (
+    select *
+    from {{ ref('orders') }}
+    where extract(year from order_date) = {{ year }}
+),
+
+customers_orders as (
+    select
+        c.customer_id,
+        c.first_name,
+        c.last_name,
+        o.order_id,
+        o.amount
+    from {{ ref('customers') }} as c
+    join orders_filtered as o
+        on c.customer_id = o.customer_id
+),
+
+customer_total_amount as (
+    select
+        customer_id,
+        first_name,
+        last_name,
+        sum(amount) as total_amount
+    from customers_orders
+    group by customer_id, first_name, last_name
+)
+
+select *
+from customer_total_amount
+order by total_amount desc


### PR DESCRIPTION
I created a new model named highest_paying_customers_2018 that calculates the total amount paid by each customer in 2018 by joining the orders and customers models on the CUSTOMER_ID column. I filtered the orders by ORDER_DATE to only include orders from 2018. Then, I grouped the results by CUSTOMER_ID, FIRST_NAME, and LAST_NAME, and calculated the sum of the AMOUNT column for each customer. Finally, I sorted the customers based on the total amount paid in descending order. The top 5 highest paying customers are Howard R., Kathleen P., Norma C., Rose M., and Christina W.